### PR TITLE
FIx cov_to_pang_samples.nf when --project has a trailing "/"

### DIFF
--- a/modular/modules/cov_to_pang_samples.nf
+++ b/modular/modules/cov_to_pang_samples.nf
@@ -40,7 +40,7 @@ process cov_to_pang_samples {
     COV_THRESHOLD = !{params.min_cov}
     NR_SAMPS_THRESHOLD = !{params.nr_samps_threshold}
     NR_SUBSAMP = !{params.nr_subsamp}
-    PROJECT = os.path.basename("!{params.project}")
+    PROJECT = os.path.basename("!{params.project}".rstrip("/"))
     
     print(f"Project is !{params.project}")
     """


### PR DESCRIPTION
`os.path.basename` is used to fetch the project name from the `--project` parameter, which can be an absolute or relative path to the output directory.

If this path had a trailing "/" (e.g. `/path/to/project/output/`), `os.path.basename` would return an empty string, so the output files for this process would not contain the project name (`.cpm.tsv`, `.cov.tsv`) and would not be recognized by the pattern matching used to define the expected output (`path("*.*.tsv", emit: pang_cpm_cov)`), halting the pipeline.